### PR TITLE
Leaflet Master branch compatibility update for new method of adding layers

### DIFF
--- a/leaflet.magnifyingglass.js
+++ b/leaflet.magnifyingglass.js
@@ -1,5 +1,4 @@
-﻿
-L.MagnifyingGlass = L.Class.extend({
+L.MagnifyingGlass = L.Layer.extend({
   includes: L.Mixin.Events,
 
   options: {
@@ -155,7 +154,20 @@ L.MagnifyingGlass = L.Class.extend({
   Shortcut to mimic common layer types' way of adding to the map
   */
   addTo: function(map) {
-    map.addLayer(this);
+    var id = L.stamp(this);
+		if (map._layers[id]) { return this; }
+		map._layers[id] = this;
+
+		this._zoomAnimated = map._zoomAnimated;
+
+		if (this.beforeAdd) {
+			this.beforeAdd(map);
+		}
+
+		this._mapToAdd = map;
+		map.whenReady(this._layerAdd, this);
+
+		return this;
   },
 });
 


### PR DESCRIPTION
changed extension of generic Class to Layer as well as updated addTo
method. This is a hack to continue to allow the bulk of the code written
to function in the .8 dev version of leaflet.

Should probably branch between leaflet master version and .7.2 and prior versions, as this plugin will have to be rewritten going forward to support the push to 1.0 leaflet but any changes will break the plugin for legacy leaflet versions.
