### PR TITLE
Replace MapQuest tiles with standard OSM tiles

### DIFF
--- a/examples/example.js
+++ b/examples/example.js
@@ -1,7 +1,7 @@
 function init() {
-  var tileUrl = 'http://otile{s}.mqcdn.com/tiles/1.0.0/osm/{z}/{x}/{y}.png';
+  var tileUrl = 'http://b.tile.openstreetmap.org/{z}/{x}/{y}.png';
   var tileOptions = {
-    attribution: '&copy; MapQuest & <a href="http://osm.org/copyright">OpenStreetMap</a> contributors',
+    attribution: '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors',
     subdomains: '1234'
   };
 

--- a/examples/example_button.js
+++ b/examples/example_button.js
@@ -9,39 +9,39 @@
 	    title: 'Toggle Magnifying Glass',
 	    forceSeparateButton: false
 	},
-	
+
 	initialize: function (magnifyingGlass, options) {
 	    this._magnifyingGlass = magnifyingGlass;
 	    // Override default options
 	    for (var i in options) if (options.hasOwnProperty(i) && this.options.hasOwnProperty(i)) this.options[i] = options[i];
 	},
-	
+
 	onAdd: function (map) {
 	    var className = 'leaflet-control-magnifying-glass', container;
-	        
+
 	    if (map.zoomControl && !this.options.forceSeparateButton) {
 		container = map.zoomControl._container;
 	    } else {
 		container = L.DomUtil.create('div', 'leaflet-bar');
 	    }
-	        
+
 	    this._createButton(this.options.title, className, container, this._clicked, map, this._magnifyingGlass);
 	    return container;
 	},
-	
+
 	_createButton: function (title, className, container, method, map, magnifyingGlass) {
 	    var link = L.DomUtil.create('a', className, container);
 	    link.href = '#';
 	    link.title = title;
-	        
+
 	    L.DomEvent
 		.addListener(link, 'click', L.DomEvent.stopPropagation)
 		.addListener(link, 'click', L.DomEvent.preventDefault)
 		.addListener(link, 'click', function() {method(map, magnifyingGlass);}, map);
-	    
+
 	    return link;
 	},
-	
+
 	_clicked: function (map, magnifyingGlass) {
 	    if (!magnifyingGlass) {
 		return;
@@ -62,11 +62,11 @@
 })();
 
 function init() {
-  var tileUrl = 'http://otile{s}.mqcdn.com/tiles/1.0.0/osm/{z}/{x}/{y}.png';
+  var tileUrl = 'http://b.tile.openstreetmap.org/{z}/{x}/{y}.png';
   var tileOptions = {
-    attribution: '&copy; MapQuest & <a href="http://osm.org/copyright">OpenStreetMap</a> contributors',
-    subdomains: '1234'
+    attribution: '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
   };
+
 
   var map = new L.Map('map', {
     center: [50.0, 10.0],
@@ -83,7 +83,7 @@ function init() {
     ]
   });
 
-  L.control.magnifyingglass(magnifyingGlass, { 
+  L.control.magnifyingglass(magnifyingGlass, {
     forceSeparateButton: true
   }).addTo(map);
 }


### PR DESCRIPTION
I like this plugin and this makes me a sad panda:

![screen shot 2016-11-21 at 12 02 31](https://cloud.githubusercontent.com/assets/1583415/20480536/3968a448-afe3-11e6-8ee9-cd43558ab199.png)

So the two basic examples now work with standard OSM tiles.

Bisou.